### PR TITLE
Updated CMake files to be compatible with latest Azure Sphere SDK

### DIFF
--- a/ModbusOnSphereA7/CMakeLists.txt
+++ b/ModbusOnSphereA7/CMakeLists.txt
@@ -4,6 +4,8 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.11)
 PROJECT(ModbusOnSphereA7 C)
 
+azsphere_configure_tools(TOOLS_REVISION "20.07")
+azsphere_configure_api(TARGET_API_SET "6")
 
 # Create executable
 ADD_EXECUTABLE(${PROJECT_NAME} main.c azure_iot.c epoll_timerfd_utilities.c modbus.c parson.c tcw241.c adam4150.c rtuovertcp.c ../crc-util.c)

--- a/ModbusOnSphereA7/CMakeSettings.json
+++ b/ModbusOnSphereA7/CMakeSettings.json
@@ -1,35 +1,33 @@
 ﻿{
     "environments": [
         {
-            "environment": "AzureSphere",
-
-            "AzureSphereTargetApiSet": "4+Beta2001"
+            "environment": "AzureSphere"
         }
     ],
     "configurations": [
-        {
-            "name": "ARM-Debug",
-            "generator": "Ninja",
-            "configurationType": "Debug",
-            "inheritEnvironments": [
-                "AzureSphere"
-            ],
-            "buildRoot": "${projectDir}\\out\\${name}-${env.AzureSphereTargetApiSet}",
-            "installRoot": "${projectDir}\\install\\${name}-${env.AzureSphereTargetApiSet}",
-            "cmakeCommandArgs": "--no-warn-unused-cli",
-            "buildCommandArgs": "-v",
-            "ctestCommandArgs": "",
-            "variables": [
-                {
-                    "name": "CMAKE_TOOLCHAIN_FILE",
-                    "value": "${env.AzureSphereDefaultSDKDir}CMakeFiles\\AzureSphereToolchain.cmake"
-                },
-                {
-                    "name": "AZURE_SPHERE_TARGET_API_SET",
-                    "value": "${env.AzureSphereTargetApiSet}"
-                }
-            ]
-        },
+      {
+        "name": "ARM-Debug",
+        "generator": "Ninja",
+        "configurationType": "Debug",
+        "inheritEnvironments": [
+          "AzureSphere"
+        ],
+        "buildRoot": "${projectDir}\\out\\${name}",
+        "installRoot": "${projectDir}\\install\\${name}",
+        "cmakeCommandArgs": "--no-warn-unused-cli",
+        "buildCommandArgs": "-v",
+        "ctestCommandArgs": "",
+        "variables": [
+          {
+            "name": "CMAKE_TOOLCHAIN_FILE",
+            "value": "${env.AzureSphereDefaultSDKDir}CMakeFiles\\AzureSphereToolchain.cmake"
+          },
+          {
+            "name": "AZURE_SPHERE_TARGET_API_SET",
+            "value": "latest-lts"
+          }
+        ]
+      },
         {
             "name": "ARM-Release",
             "generator": "Ninja",
@@ -37,8 +35,8 @@
             "inheritEnvironments": [
                 "AzureSphere"
             ],
-            "buildRoot": "${projectDir}\\out\\${name}-${env.AzureSphereTargetApiSet}",
-            "installRoot": "${projectDir}\\install\\${name}-${env.AzureSphereTargetApiSet}",
+            "buildRoot": "${projectDir}\\out\\${name}",
+            "installRoot": "${projectDir}\\install\\${name}",
             "cmakeCommandArgs": "--no-warn-unused-cli",
             "buildCommandArgs": "-v",
             "ctestCommandArgs": "",
@@ -48,8 +46,8 @@
                     "value": "${env.AzureSphereDefaultSDKDir}CMakeFiles\\AzureSphereToolchain.cmake"
                 },
                 {
-                    "name": "AZURE_SPHERE_TARGET_API_SET",
-                    "value": "${env.AzureSphereTargetApiSet}"
+                  "name": "AZURE_SPHERE_TARGET_API_SET",
+                  "value": "latest-lts"
                 }
             ]
         }

--- a/ModbusOnSphereA7/modbus.c
+++ b/ModbusOnSphereA7/modbus.c
@@ -185,7 +185,7 @@ modbus_t ModbusConnectRtu(serialSetup setup, size_t timeout)
     {
         memset(hndl, 0, sizeof(struct _modbus_t));
         // Open connection to real-time capable application.
-        sockFd = Application_Socket(rtAppComponentId);
+        sockFd = Application_Connect(rtAppComponentId);
         if (sockFd == -1)
         {
             Log_Debug("Error: Unable to create Application socket: %d (%s)\n", errno, strerror(errno));

--- a/ModbusOnSphereM4/CMakeLists.txt
+++ b/ModbusOnSphereM4/CMakeLists.txt
@@ -4,6 +4,8 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.11)
 PROJECT(ModbusOnSphereM4 C)
 
+# Set the tools revision
+azsphere_configure_tools(TOOLS_REVISION "20.07")
 
 # Create executable
 ADD_EXECUTABLE(${PROJECT_NAME} main.c mt3620-intercore.c mt3620-uart.c mt3620-timer.c mt3620-gpio.c ../crc-util.c message-handler.c)

--- a/ModbusOnSphereM4/CMakeSettings.json
+++ b/ModbusOnSphereM4/CMakeSettings.json
@@ -1,9 +1,7 @@
 ﻿{
   "environments": [
     {
-      "environment": "AzureSphere",
-
-      "AzureSphereTargetApiSet": "4+Beta2001"
+      "environment": "AzureSphere"
     }
   ],
   "configurations": [
@@ -15,7 +13,7 @@
         "AzureSphere"
       ],
       "buildRoot": "${projectDir}\\out\\${name}-${env.AzureSphereTargetApiSet}",
-      "installRoot": "${projectDir}\\install\\${name}-${env.AzureSphereTargetApiSet}",
+      "installRoot": "${projectDir}\\install\\${name}",
       "cmakeCommandArgs": "--no-warn-unused-cli",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
@@ -23,10 +21,6 @@
         {
           "name": "CMAKE_TOOLCHAIN_FILE",
           "value": "${env.AzureSphereDefaultSDKDir}CMakeFiles\\AzureSphereRTCoreToolchain.cmake"
-        },
-        {
-          "name": "AZURE_SPHERE_TARGET_API_SET",
-          "value": "${env.AzureSphereTargetApiSet}"
         },
         {
           "name": "ARM_GNU_PATH",
@@ -42,7 +36,7 @@
         "AzureSphere"
       ],
       "buildRoot": "${projectDir}\\out\\${name}-${env.AzureSphereTargetApiSet}",
-      "installRoot": "${projectDir}\\install\\${name}-${env.AzureSphereTargetApiSet}",
+      "installRoot": "${projectDir}\\install\\${name}",
       "cmakeCommandArgs": "--no-warn-unused-cli",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
@@ -50,10 +44,6 @@
         {
           "name": "CMAKE_TOOLCHAIN_FILE",
           "value": "${env.AzureSphereDefaultSDKDir}CMakeFiles\\AzureSphereRTCoreToolchain.cmake"
-        },
-        {
-          "name": "AZURE_SPHERE_TARGET_API_SET",
-          "value": "${env.AzureSphereTargetApiSet}"
         },
         {
           "name": "ARM_GNU_PATH",


### PR DESCRIPTION
Updated CMake files to be compatible with latest Azure Sphere SDK release.  There was only one application code change that was required.  The API call Application_Socket() was deprecated and changed to Application_Connect().

To determine what needed to be changed, I opened the latest Microsoft Samples Repo and compared the CMake files against the AzureIoT Example for the A7 application, and the helloWorld BareMetal Example for the M4 application.

Everything builds clean.  I don't have all the hardware to test all the features.

